### PR TITLE
Add a minimal reporter for full test (`npm test`)

### DIFF
--- a/utils/run-tests.js
+++ b/utils/run-tests.js
@@ -106,6 +106,10 @@ else {
                 failedTest.forEach(function(file) {
                     SpawnSync(exePath, [cwd, '--test', file], {stdio: 'inherit'});
                 });
+            } else {
+                console.log(Chalk.green('================================='));
+                console.log(Chalk.green( 'All tests passed, Congratulations! '));
+                console.log(Chalk.green('================================='));
             }
         }
     });


### PR DESCRIPTION
- Add another commander option 'test-full' for handling full test `npm test`
- Use `async.eachSeries` to run full tests, so we can build ipc channel for collecting data from child process
- In editor-framework test-runner, use almost silent reporter `SpecFull` for full tests, and send IPC message with test file path for failed tests.
- At the end of `run-tests` process, re-run all the failed tests with normal `Spec` reporter to show details.

This PR requires editor-framework switch to `alt-test-reporter` branch to work.