### PR TITLE
gulp: include sharedPackages into local-setting

### DIFF
--- a/utils/gulp-tasks/setup-tasks.js
+++ b/utils/gulp-tasks/setup-tasks.js
@@ -40,6 +40,7 @@ gulp.task('setup-branch', function(cb) {
         }
         obj.branch = {
             hosts: {},
+            submodules: {},
             builtins: {},
             sharedPackages: {}
         };
@@ -47,12 +48,15 @@ gulp.task('setup-branch', function(cb) {
         (pjson.hosts || []).forEach(function(entry) {
             obj.branch.hosts[entry] = "master";
         });
+        (pjson.submodules || []).forEach(function(entry) {
+            obj.branch.submodules[entry] = "master";
+        });
         (pjson.builtins || []).forEach(function(entry) {
             obj.branch.builtins[entry] = "master";
         });
         (pjson.sharedPackages || []).forEach(function(entry) {
             obj.branch.sharedPackages[entry] = "master";
-        })
+        });
         Fs.writeFileSync('local-setting.json', JSON.stringify(obj, null, '  '));
         console.log("Setup submodule branch local setting. You can change 'local-setting.json' to specify your branches.");
         cb();

--- a/utils/gulp-tasks/setup-tasks.js
+++ b/utils/gulp-tasks/setup-tasks.js
@@ -14,7 +14,10 @@ gulp.task('setup-branch', function(cb) {
     if ( Fs.existsSync('local-setting.json') ) {
         try {
             var jsonObj = JSON.parse(Fs.readFileSync('local-setting.json'));
-            if (jsonObj.branch) {
+            if (jsonObj.branch &&
+                jsonObj.branch.submodules &&
+                jsonObj.branch.builtins &&
+                jsonObj.branch.sharedPackages) {
                 return cb();
             } else {
                 hasBranchSetting = false;
@@ -38,14 +41,18 @@ gulp.task('setup-branch', function(cb) {
         obj.branch = {
             hosts: {},
             builtins: {},
+            sharedPackages: {}
         };
 
-        pjson.hosts.forEach(function(entry) {
+        (pjson.hosts || []).forEach(function(entry) {
             obj.branch.hosts[entry] = "master";
         });
-        pjson.builtins.forEach(function(entry) {
+        (pjson.builtins || []).forEach(function(entry) {
             obj.branch.builtins[entry] = "master";
         });
+        (pjson.sharedPackages || []).forEach(function(entry) {
+            obj.branch.sharedPackages[entry] = "master";
+        })
         Fs.writeFileSync('local-setting.json', JSON.stringify(obj, null, '  '));
         console.log("Setup submodule branch local setting. You can change 'local-setting.json' to specify your branches.");
         cb();


### PR DESCRIPTION
Hey @nantas I occurred an error when I ran the gulp task "update-shared-packages":

```js
TypeError: Cannot read property 'package-examples' of undefined
    at /Users/yorkieliu/workspace/firebox/fireball/gulpfile.js:421:51
```

which is caused by missing `branch.sharedPackages` in generated local-setting.json, and I found the following 2 issues there:

1. we don't set the `branch.sharedPackages`
2. now the complete `branch` should have `submodules`, `builtins` and `sharedPackages`, but the line just check if `branch` is an object, so If my local `branch` only has `submodules` and `builtins`, it never gets update.

BTW I found an almost same task in editor-framework: https://github.com/fireball-x/editor-framework/blob/master/utils/gulp-tasks/setup-tasks.js#L11-L56, should we use the same resource for generating the `branch` object in `local-setting.json`?

/cc @jwu 