### PR TITLE
init: build api and register api protocol

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -115,7 +115,7 @@ gulp.task('package-studio', function(cb) {
     });
 });
 
-gulp.task('fireball', function(cb) {
+gulp.task('fireball', ['cp-apisrc'], function(cb) {
     var Commander = require('commander');
     Commander.option('--path <path>', 'Run open fireball project in path')
         .parse(process.argv);


### PR DESCRIPTION
This *feature-request* PR did the following items:

- run the gulp task "cp-apisrc" before running the "fireball"
- register the "api://" protocol for api source directory

This one is working with https://github.com/fireball-packages/code-editor/pull/3

R=@nantas @jwu 
/cc @jareguo 